### PR TITLE
Make IDs constant through inspection of stack

### DIFF
--- a/application/dash_application/dash_id.py
+++ b/application/dash_application/dash_id.py
@@ -5,10 +5,17 @@ from inspect import getmodule, stack
 ## generating IDs with module names appended, effectively making IDs
 ## appear local to module.
 
-def init_ids(names):
+## Optional parameter allows developer to define name appended to ID
+## rather than automatically getting the name of the calling module.
+## This introduces the danger of the developer setting the same name
+## twice, which will cause Dash to cease correct rendering of pages
+## due to ID conflict. Please use carefully.
+def init_ids(names, moduleName=None):
     results = {}
-    callingModule = getmodule(stack()[1][0])
+    if not moduleName:
+        callingModule = getmodule(stack()[1][0])
+        moduleName = callingModule.__name__
     for name in names:
         ## Replace '.' with '_' because IDs may not have '.' in Dash
-        results[name] = name + '--' + callingModule.__name__.replace('.', '_')
+        results[name] = name + '--' + moduleName.replace('.', '_')
     return results

--- a/application/dash_application/dash_id.py
+++ b/application/dash_application/dash_id.py
@@ -1,9 +1,14 @@
-import uuid
+from inspect import getmodule, stack
 
-### Helps with graph UUIDs
+### Helps with graph IDs
+## Dash requires unique IDs for the entire app. Reduce mental overhead by 
+## generating IDs with module names appended, effectively making IDs
+## appear local to module.
 
 def init_ids(names):
     results = {}
+    callingModule = getmodule(stack()[1][0])
     for name in names:
-        results[name] = name + '--' + str(uuid.uuid4())
+        ## Replace '.' with '_' because IDs may not have '.' in Dash
+        results[name] = name + '--' + callingModule.__name__.replace('.', '_')
     return results


### PR DESCRIPTION
_ _ name _ _ on its own would always resolve to 'dash_id'. Use inspect
module to get name of module from which init_ids has been called.